### PR TITLE
Make `send`, `recv` and `close` methods of `BlimpGroundWebsocketStreamPair` borrow self non-mutably, in order to allow accessing it from many tasks concurrently

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -30,11 +30,19 @@ impl BlimpGroundWebsocketClient {
         self.stream = None;
         Ok(())
     }
-    pub async fn send(&mut self, message: MessageV2G) -> Result<(), Box<dyn std::error::Error>> {
-        self.stream.as_mut().unwrap().send(message).await
+    pub async fn send(&self, message: MessageV2G) -> Result<(), Box<dyn std::error::Error>> {
+        self.stream
+            .as_ref()
+            .expect("Unconnected client attempted to send")
+            .send(message)
+            .await
     }
 
-    pub async fn recv(&mut self) -> Result<MessageG2V, Box<dyn std::error::Error + Send + Sync>> {
-        self.stream.as_mut().unwrap().recv().await
+    pub async fn recv(&self) -> Result<MessageG2V, Box<dyn std::error::Error + Send + Sync>> {
+        self.stream
+            .as_ref()
+            .expect("Unconnected client attempted to receive")
+            .recv()
+            .await
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,9 +1,10 @@
-use crate::schema::MessageV2G;
-use crate::stream::BlimpGroundWebsocketStreamPair;
-use crate::MessageG2V;
 use tokio::net::TcpStream;
 use tokio_tungstenite::tungstenite::handshake::client::Request;
 use tokio_tungstenite::{connect_async, tungstenite, MaybeTlsStream};
+
+use crate::schema::MessageV2G;
+use crate::stream::BlimpGroundWebsocketStreamPair;
+use crate::MessageG2V;
 
 pub struct BlimpGroundWebsocketClient {
     url: String,

--- a/tests/send.rs
+++ b/tests/send.rs
@@ -1,10 +1,11 @@
-use blimp_ground_ws_interface::{
-    BlimpGroundWebsocketClient, BlimpGroundWebsocketServer, MessageG2V, MessageV2G, VizInterest,
-};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::{oneshot, Mutex as TMutex};
 use tokio::time::{timeout, Duration};
+
+use blimp_ground_ws_interface::{
+    BlimpGroundWebsocketClient, BlimpGroundWebsocketServer, MessageG2V, MessageV2G, VizInterest,
+};
 
 const CLIENT_MESSAGE: MessageV2G = MessageV2G::DeclareInterest(VizInterest {
     motors: true,

--- a/tests/send.rs
+++ b/tests/send.rs
@@ -28,7 +28,7 @@ async fn test_client_send() {
                 .send(server.get_address().unwrap())
                 .expect("Did not send the address properly");
             server
-                .run(move |mut pair| {
+                .run(move |pair| {
                     let tx = tx.clone();
                     async move {
                         let message = pair
@@ -82,7 +82,7 @@ async fn test_server_send() {
                 .send(server.get_address().unwrap())
                 .expect("Did not send the address properly");
             server
-                .run(|mut pair| async move {
+                .run(|pair| async move {
                     pair.send(SERVER_MESSAGE)
                         .await
                         .expect("Failed to send server message");


### PR DESCRIPTION
Fixes #3.