### PR TITLE
Utilize `Sec-WebSocket-Protocol` header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ postcard = { version = "1.0.10", features = ["use-std"] }
 serde = { version = "1.0.215", features = ["default", "serde_derive"] }
 tokio = { version = "1.44.2", features = ["full"] }
 tokio-tungstenite = "0.26.2"
+tungstenite = "0.26.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 futures-util = "0.3.31"
 postcard = { version = "1.0.10", features = ["use-std"] }
 serde = { version = "1.0.215", features = ["default", "serde_derive"] }
+serde_json = "1.0.140"
 tokio = { version = "1.44.2", features = ["full"] }
 tokio-tungstenite = "0.26.2"
 tungstenite = "0.26.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blimp_ground_ws_interface"
-version = "0.2.0"
+version = "1.0.0"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ serde = { version = "1.0.215", features = ["default", "serde_derive"] }
 tokio = { version = "1.44.2", features = ["full"] }
 tokio-tungstenite = "0.26.2"
 tungstenite = "0.26.2"
+phf = { version = "0.11.3", features = ["macros"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,20 +8,22 @@ use crate::MessageG2V;
 use crate::subprotocol::BlimpSubprotocol;
 
 pub struct BlimpGroundWebsocketClient {
-    url: String,
-    stream: Option<BlimpGroundWebsocketStreamPair<MaybeTlsStream<TcpStream>>>,
+    pub url: String,
+    pub subprotocol: BlimpSubprotocol,
+    stream: Option<BlimpGroundWebsocketStreamPair<MaybeTlsStream<TcpStream>>>
 }
 impl BlimpGroundWebsocketClient {
     pub fn new(url: &str) -> Self {
         Self {
             url: url.to_string(),
             stream: None,
+            subprotocol: BlimpSubprotocol::default()
         }
     }
     fn get_request(&self) -> Result<Request, tungstenite::Error> {
         Ok(Request::builder()
             .uri(self.url.as_str())
-            .header("Sec-WebSocket-Protocol", BlimpSubprotocol::default().to_string())
+            .header("Sec-WebSocket-Protocol", self.subprotocol.to_string())
             .header("Host", "")
             .header("Origin", "")
             .header("Connection", "Upgrade")
@@ -34,7 +36,7 @@ impl BlimpGroundWebsocketClient {
     pub async fn connect(&mut self) -> Result<(), tungstenite::Error> {
         let request = self.get_request()?;
         let (stream, _response) = connect_async(request).await?;
-        self.stream = Some(BlimpGroundWebsocketStreamPair::from_stream(stream, BlimpSubprotocol::default()));
+        self.stream = Some(BlimpGroundWebsocketStreamPair::from_stream(stream, self.subprotocol.clone()));
         Ok(())
     }
     pub async fn disconnect(&mut self) -> Result<(), tungstenite::Error> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -42,7 +42,7 @@ impl BlimpGroundWebsocketClient {
         self.stream = None;
         Ok(())
     }
-    pub async fn send(&self, message: MessageV2G) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn send(&self, message: MessageV2G) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         self.stream
             .as_ref()
             .expect("Unconnected client attempted to send")

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,7 +3,7 @@ use tokio_tungstenite::tungstenite::handshake::client::Request;
 use tokio_tungstenite::{connect_async, tungstenite, MaybeTlsStream};
 
 use crate::schema::MessageV2G;
-use crate::stream::BlimpGroundWebsocketStreamPair;
+use crate::stream::{BlimpGroundWebsocketStreamPair, BlimpSubprotocol};
 use crate::MessageG2V;
 
 pub struct BlimpGroundWebsocketClient {
@@ -23,7 +23,7 @@ impl BlimpGroundWebsocketClient {
     pub async fn connect(&mut self) -> Result<(), tungstenite::Error> {
         let request = self.get_request()?;
         let (stream, _response) = connect_async(request).await?;
-        self.stream = Some(BlimpGroundWebsocketStreamPair::from_stream(stream));
+        self.stream = Some(BlimpGroundWebsocketStreamPair::from_stream(stream, BlimpSubprotocol::PostcardV1));
         Ok(())
     }
     pub async fn disconnect(&mut self) -> Result<(), tungstenite::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,10 @@ mod client;
 mod schema;
 mod stream;
 mod server;
+mod subprotocol;
 
 pub use client::BlimpGroundWebsocketClient;
 pub use server::BlimpGroundWebsocketServer;
 pub use stream::BlimpGroundWebsocketStreamPair;
 pub use schema::*;
+pub use subprotocol::{BlimpSubprotocol, BlimpSubprotocolFlavour, SubprotocolValidationError};

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,3 +1,7 @@
+pub const PROTOCOL_ORGANIZATION: &str = "spacecoffee";
+pub const PROTOCOL_PROJECT: &str = "blimp";
+pub const PROTOCOL_VERSION: u16 = 1;
+
 /// Messages sent by the server
 #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq, Clone)]
 pub enum MessageG2V {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,15 +1,15 @@
 use std::future::Future;
 use std::net::SocketAddr;
+use std::str::FromStr;
 use std::sync::Arc;
 
+use crate::stream::BlimpGroundWebsocketStreamPair;
+use crate::subprotocol::BlimpSubprotocol;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::oneshot;
 use tokio_tungstenite::accept_hdr_async;
 use tungstenite;
 use tungstenite::http::{HeaderValue, StatusCode};
-use crate::stream::{BlimpGroundWebsocketStreamPair, ALLOWED_PROTOCOLS};
-use phf::phf_map;
-
 
 pub struct BlimpGroundWebsocketServer {
     url: String,
@@ -37,16 +37,18 @@ impl BlimpGroundWebsocketServer {
         self.listener = None;
     }
 
-    fn get_subprotocol(request: &tungstenite::handshake::server::Request) -> Option<&str> {
+    fn get_subprotocol(request: &tungstenite::handshake::server::Request) -> Option<BlimpSubprotocol> {
         let subprotocols: Option<Vec<&str>> = request.headers()
             .get("Sec-WebSocket-Protocol")
             .and_then(|value| value.to_str().ok())
             .map(|s| s.split(',').map(str::trim).collect());
-
-        subprotocols
-            .as_ref()
-            .and_then(|protos| protos.iter().find(|p| ALLOWED_PROTOCOLS.contains_key(**p)))
-            .copied()
+        
+        for subprotocol_name in subprotocols? {
+            if let Ok(subprotocol) = BlimpSubprotocol::from_str(subprotocol_name) {
+                return Some(subprotocol)
+            }
+        }
+        None
     }
     pub async fn run<F, Fut>(
         &mut self,
@@ -75,8 +77,8 @@ impl BlimpGroundWebsocketServer {
                             Err(tungstenite::handshake::server::Response::builder().status(StatusCode::BAD_REQUEST).body(Some("No provided valid subprotocols".to_string())).unwrap())
                         }
                         Some(protocol) => {
-                            subprotocol_tx.send(protocol.to_string()).unwrap();
-                            res.headers_mut().insert("Sec-WebSocket-Protocol", HeaderValue::from_str(protocol).unwrap());
+                            res.headers_mut().insert("Sec-WebSocket-Protocol", HeaderValue::from_str(protocol.to_string().as_str()).unwrap());
+                            subprotocol_tx.send(protocol).unwrap();
                             Ok(res)
                         }
                     }
@@ -84,9 +86,9 @@ impl BlimpGroundWebsocketServer {
 
             let websocket_stream = accept_hdr_async(tcp_stream, hdr_handler).await?;
 
-            let subprotocol = ALLOWED_PROTOCOLS.get(subprotocol_rx.await?.as_str()).unwrap();
+            let subprotocol = subprotocol_rx.await?;
 
-            let pair = BlimpGroundWebsocketStreamPair::from_stream(websocket_stream, subprotocol.to_owned());
+            let pair = BlimpGroundWebsocketStreamPair::from_stream(websocket_stream, subprotocol);
             let handler = Arc::clone(&owned_handler);
             tokio::spawn(async move {
                 handler(pair).await;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,23 +1,12 @@
-use std::cmp::PartialEq;
+use crate::subprotocol::{BlimpSubprotocol, BlimpSubprotocolFlavour};
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
-use phf::phf_map;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::RwLock as TRwLock;
 use tokio_tungstenite::{tungstenite, WebSocketStream};
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum BlimpSubprotocol {
-    JsonV1,
-    PostcardV1,
-}
-
-pub static ALLOWED_PROTOCOLS: phf::Map<&'static str, BlimpSubprotocol> = phf_map! {
-    "spacecoffee.blimp.v1.json" => BlimpSubprotocol::JsonV1,
-    "spacecoffee.blimp.v1.postcard" => BlimpSubprotocol::PostcardV1,
-};
 pub struct BlimpGroundWebsocketStreamPair<T> {
     read_stream: TRwLock<SplitStream<WebSocketStream<T>>>,
     write_stream: TRwLock<SplitSink<WebSocketStream<T>, tungstenite::Message>>,
@@ -30,7 +19,7 @@ where
 {
     pub(crate) fn from_stream(stream: WebSocketStream<T>, subprotocol: BlimpSubprotocol) -> Self {
         let (write_stream, read_stream) = stream.split();
-        if subprotocol != BlimpSubprotocol::PostcardV1 {
+        if subprotocol.flavour != BlimpSubprotocolFlavour::Postcard {
             unimplemented!("Only Postcard protocol is implemented for now")
         }
         Self {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,25 +1,42 @@
+use std::cmp::PartialEq;
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
+use phf::phf_map;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::RwLock as TRwLock;
 use tokio_tungstenite::{tungstenite, WebSocketStream};
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BlimpSubprotocol {
+    JsonV1,
+    PostcardV1,
+}
+
+pub static ALLOWED_PROTOCOLS: phf::Map<&'static str, BlimpSubprotocol> = phf_map! {
+    "spacecoffee.blimp.v1.json" => BlimpSubprotocol::JsonV1,
+    "spacecoffee.blimp.v1.postcard" => BlimpSubprotocol::PostcardV1,
+};
 pub struct BlimpGroundWebsocketStreamPair<T> {
     read_stream: TRwLock<SplitStream<WebSocketStream<T>>>,
     write_stream: TRwLock<SplitSink<WebSocketStream<T>, tungstenite::Message>>,
+    subprotocol: BlimpSubprotocol
 }
 
 impl<T> BlimpGroundWebsocketStreamPair<T>
 where
     T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
-    pub(crate) fn from_stream(stream: WebSocketStream<T>) -> Self {
+    pub(crate) fn from_stream(stream: WebSocketStream<T>, subprotocol: BlimpSubprotocol) -> Self {
         let (write_stream, read_stream) = stream.split();
+        if subprotocol != BlimpSubprotocol::PostcardV1 {
+            unimplemented!("Only Postcard protocol is implemented for now")
+        }
         Self {
             read_stream: TRwLock::new(read_stream),
             write_stream: TRwLock::new(write_stream),
+            subprotocol
         }
     }
     pub async fn send<S: Serialize>(&self, message: S) -> Result<(), Box<dyn std::error::Error>> {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -19,9 +19,6 @@ where
 {
     pub(crate) fn from_stream(stream: WebSocketStream<T>, subprotocol: BlimpSubprotocol) -> Self {
         let (write_stream, read_stream) = stream.split();
-        if subprotocol.flavour != BlimpSubprotocolFlavour::Postcard {
-            unimplemented!("Only Postcard protocol is implemented for now")
-        }
         Self {
             read_stream: TRwLock::new(read_stream),
             write_stream: TRwLock::new(write_stream),

--- a/src/subprotocol.rs
+++ b/src/subprotocol.rs
@@ -1,0 +1,70 @@
+use crate::{PROTOCOL_ORGANIZATION, PROTOCOL_PROJECT, PROTOCOL_VERSION};
+use phf::phf_map;
+use std::fmt::Display;
+use std::str::FromStr;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BlimpSubprotocolFlavour {
+    Json,
+    Postcard,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum SubprotocolValidationError {
+    InvalidProtocol,
+    IncompatibleVersion,
+    UnsupportedFlavour
+}
+
+#[derive(Debug, PartialEq)]
+pub struct BlimpSubprotocol {
+    pub version: u16,
+    pub flavour: BlimpSubprotocolFlavour
+}
+
+impl Default for BlimpSubprotocol {
+    fn default() -> Self {
+        BlimpSubprotocol { version: PROTOCOL_VERSION, flavour: BlimpSubprotocolFlavour::Postcard }
+    }
+}
+pub const SUPPORTED_VERSIONS: [u16; 1] = [1];
+pub static SUPPORTED_FLAVOURS: phf::Map<&'static str, BlimpSubprotocolFlavour> = phf_map! {
+    "json" => BlimpSubprotocolFlavour::Json,
+    "postcard" => BlimpSubprotocolFlavour::Postcard,
+};
+impl FromStr for BlimpSubprotocol {
+    type Err = SubprotocolValidationError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let namespaces: Vec<&str> = s.split(".").collect();
+        if namespaces.len() != 4 {
+            return Err(SubprotocolValidationError::InvalidProtocol)
+        }
+        let [organization, project, version, flavour] = namespaces.as_slice() else {
+            return Err(SubprotocolValidationError::InvalidProtocol)
+        };
+        if *organization != PROTOCOL_ORGANIZATION || *project != PROTOCOL_PROJECT {
+            return Err(SubprotocolValidationError::InvalidProtocol)
+        }
+        let Some(parsed_version) = version.strip_prefix("v").and_then(|v| v.parse::<u16>().ok()) else {
+            return Err(SubprotocolValidationError::InvalidProtocol)
+        };
+        if !SUPPORTED_VERSIONS.contains(&parsed_version) {
+            return Err(SubprotocolValidationError::IncompatibleVersion)
+        }
+        let Some(parsed_flavour) = SUPPORTED_FLAVOURS.get(flavour) else {
+            return Err(SubprotocolValidationError::UnsupportedFlavour)
+        };
+        Ok(Self {version: parsed_version, flavour: parsed_flavour.to_owned()})
+    }
+}
+
+impl Display for BlimpSubprotocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let flavour_name = match self.flavour {
+            BlimpSubprotocolFlavour::Json => "json",
+            BlimpSubprotocolFlavour::Postcard => "postcard"
+        };
+
+        write!(f, "{}", format!("{}.{}.v{}.{}", PROTOCOL_ORGANIZATION, PROTOCOL_PROJECT, self.version, flavour_name))
+    }
+}

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -1,0 +1,43 @@
+use std::net::SocketAddr;
+use tokio::sync::oneshot;
+use tokio_tungstenite::{connect_async, connect_async_with_config};
+use tungstenite::http::Request;
+use blimp_ground_ws_interface::{BlimpGroundWebsocketServer, MessageV2G};
+
+#[tokio::test]
+async fn test_choose_protocol() {
+    let (address_tx, address_rx) = oneshot::channel::<SocketAddr>();
+
+    let server = {
+        tokio::spawn(async move {
+            let mut server = BlimpGroundWebsocketServer::new("localhost:0");
+            server.bind().await.expect("Failed address bind");
+            address_tx
+                .send(server.get_address().unwrap())
+                .expect("Did not send the address properly");
+            server
+                .run(move |_| { async move {} })
+                .await
+                .expect("Server failed");
+        })
+    };
+
+    let address = address_rx.await.expect("Failed to receive target address");
+    let url = format!("ws://{}", address);
+    
+    let request = Request::builder()
+        .uri(url)
+        .header("Host", "")
+        .header("Origin", "")
+        .header("Connection", "Upgrade")
+        .header("Upgrade", "websocket")
+        .header("Sec-WebSocket-Version", "13")
+        .header("Sec-WebSocket-Protocol", "spacecoffee.blimp.v2137.json, spacecoffee.blimp.v1.postcard")
+        .header("Sec-WebSocket-Key", tungstenite::handshake::client::generate_key())
+        .body(())
+        .expect("Failed to build the request");
+    
+    let (mut stream, response) = connect_async(request).await.expect("Failed to connect");
+    stream.close(None).await.expect("Failed to close");
+    assert_eq!(response.headers().get("Sec-WebSocket-Protocol").unwrap().to_str().unwrap(), "spacecoffee.blimp.v1.postcard");
+}

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -1,14 +1,31 @@
+use blimp_ground_ws_interface::{BlimpGroundWebsocketServer, BlimpSubprotocol, BlimpSubprotocolFlavour, SubprotocolValidationError};
 use std::net::SocketAddr;
+use std::str::FromStr;
 use tokio::sync::oneshot;
-use tokio_tungstenite::{connect_async, connect_async_with_config};
+use tokio_tungstenite::connect_async;
 use tungstenite::http::Request;
-use blimp_ground_ws_interface::{BlimpGroundWebsocketServer, MessageV2G};
+
+#[test]
+fn test_subprotocol_export() {
+    assert_eq!(BlimpSubprotocol { version: 1, flavour: BlimpSubprotocolFlavour::Postcard }.to_string(), "spacecoffee.blimp.v1.postcard");
+    assert_eq!(BlimpSubprotocol { version: 2, flavour: BlimpSubprotocolFlavour::Json }.to_string(), "spacecoffee.blimp.v2.json");
+}
+
+#[test]
+fn test_subprotocol_parse() {
+    assert_eq!(BlimpSubprotocol { version: 1, flavour: BlimpSubprotocolFlavour::Postcard }, BlimpSubprotocol::from_str("spacecoffee.blimp.v1.postcard").expect("Parse fail"));
+    assert_eq!(BlimpSubprotocol { version: 1, flavour: BlimpSubprotocolFlavour::Json }, BlimpSubprotocol::from_str("spacecoffee.blimp.v1.json").expect("Parse fail"));
+    assert!(BlimpSubprotocol::from_str("vfly.blimp.v1.postcard").is_err_and(|e|  e == SubprotocolValidationError::InvalidProtocol));
+    assert!(BlimpSubprotocol::from_str("spacecoffee.mper.v1.postcard").is_err_and(|e|  e == SubprotocolValidationError::InvalidProtocol));
+    assert!(BlimpSubprotocol::from_str("spacecoffee.blimp.v2137.json").is_err_and(|e|  e == SubprotocolValidationError::IncompatibleVersion));
+    assert!(BlimpSubprotocol::from_str("spacecoffee.blimp.v1.xml").is_err_and(|e|  e == SubprotocolValidationError::UnsupportedFlavour));
+}
 
 #[tokio::test]
 async fn test_choose_protocol() {
     let (address_tx, address_rx) = oneshot::channel::<SocketAddr>();
 
-    let server = {
+    let _server = {
         tokio::spawn(async move {
             let mut server = BlimpGroundWebsocketServer::new("localhost:0");
             server.bind().await.expect("Failed address bind");

--- a/tests/send.rs
+++ b/tests/send.rs
@@ -3,9 +3,7 @@ use std::sync::Arc;
 use tokio::sync::{oneshot, Mutex as TMutex, Notify};
 use tokio::time::{timeout, Duration};
 
-use blimp_ground_ws_interface::{
-    BlimpGroundWebsocketClient, BlimpGroundWebsocketServer, MessageG2V, MessageV2G, VizInterest,
-};
+use blimp_ground_ws_interface::{BlimpGroundWebsocketClient, BlimpGroundWebsocketServer, BlimpSubprotocol, BlimpSubprotocolFlavour, MessageG2V, MessageV2G, VizInterest};
 
 const CLIENT_MESSAGE: MessageV2G = MessageV2G::DeclareInterest(VizInterest {
     motors: true,
@@ -70,6 +68,65 @@ async fn test_client_send() {
     assert_eq!(CLIENT_MESSAGE, received);
 }
 
+#[tokio::test]
+async fn test_client_send_json() {
+    let (tx, rx) = oneshot::channel();
+    let tx = Arc::new(TMutex::new(Some(tx)));
+
+    let (address_tx, address_rx) = oneshot::channel::<SocketAddr>();
+
+    let server = {
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            let mut server = BlimpGroundWebsocketServer::new("localhost:0");
+            server.bind().await.expect("Failed address bind");
+            address_tx
+                .send(server.get_address().unwrap())
+                .expect("Did not send the address properly");
+            server
+                .run(move |pair| {
+                    let tx = tx.clone();
+                    async move {
+                        let message = pair
+                            .recv::<MessageV2G>()
+                            .await
+                            .expect("Failed to receive client message");
+                        tx.lock()
+                            .await
+                            .take()
+                            .expect("Tx already taken")
+                            .send(message)
+                            .expect("Failed to send");
+                    }
+                })
+                .await
+                .expect("Server failed");
+        })
+    };
+
+    let address = address_rx.await.expect("Failed to receive target address");
+    let mut client = BlimpGroundWebsocketClient::new(format!("ws://{}", address).as_str());
+    client.subprotocol = BlimpSubprotocol{version: 1, flavour: BlimpSubprotocolFlavour::Json};
+
+    client
+        .connect()
+        .await
+        .expect("Failed to connect the client");
+    client
+        .send(CLIENT_MESSAGE)
+        .await
+        .expect("Failed to send the client message");
+
+    let received = timeout(Duration::from_secs(1), rx)
+        .await
+        .expect("Timed out waiting for client message")
+        .expect("Receive failed");
+
+    server.abort();
+
+    assert_eq!(CLIENT_MESSAGE, received);
+}
+
 const SERVER_MESSAGE: MessageG2V = MessageG2V::MotorSpeed { id: 0, speed: 0 };
 #[tokio::test]
 async fn test_server_send() {
@@ -95,6 +152,46 @@ async fn test_server_send() {
 
     let address = address_rx.await.expect("Failed to receive target address");
     let mut client = BlimpGroundWebsocketClient::new(format!("ws://{}", address).as_str());
+
+    client
+        .connect()
+        .await
+        .expect("Failed to connect the client");
+
+    let received = timeout(Duration::from_secs(1), client.recv())
+        .await
+        .expect("Timed out waiting for client message")
+        .expect("Receive failed");
+
+    server.abort();
+
+    assert_eq!(SERVER_MESSAGE, received);
+}
+#[tokio::test]
+async fn test_server_send_json() {
+    let (address_tx, address_rx) = oneshot::channel::<SocketAddr>();
+    let server = {
+        tokio::spawn(async move {
+            let mut server = BlimpGroundWebsocketServer::new("localhost:0");
+            server.bind().await.expect("Failed address bind");
+            address_tx
+                .send(server.get_address().unwrap())
+                .expect("Did not send the address properly");
+            server
+                .run(|pair| async move {
+                    pair.send(SERVER_MESSAGE)
+                        .await
+                        .expect("Failed to send server message");
+                    pair.close().await.expect("Failed to close");
+                })
+                .await
+                .expect("Server failed");
+        })
+    };
+
+    let address = address_rx.await.expect("Failed to receive target address");
+    let mut client = BlimpGroundWebsocketClient::new(format!("ws://{}", address).as_str());
+    client.subprotocol = BlimpSubprotocol{version: 1, flavour: BlimpSubprotocolFlavour::Json};
 
     client
         .connect()


### PR DESCRIPTION
Server should use [`Sec-WebSockeet-Protocol`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Protocol) header in order to determine which protocols (JSON or Postcard) are supported by the client.
Client should send desired protocol(s) in this header.
Resolves #2.